### PR TITLE
Fix output path for cards JSON

### DIFF
--- a/src/export.ts
+++ b/src/export.ts
@@ -63,7 +63,7 @@ async function main() {
   const cards = await getAllCards(sets);
 
   // Schritt 3: Karten als JSON exportieren
-  const outPath = path.join(__dirname, "..", "..", "data", "cards.json");
+  const outPath = path.join(__dirname, "..", "data", "cards.json");
   await fs.ensureDir(path.dirname(outPath));
   await fs.writeJson(outPath, cards, { spaces: 2 });
 


### PR DESCRIPTION
## Summary
- adjust output path in `src/export.ts` so that generated data lands in `data/cards.json`

## Testing
- `npm run export`

------
https://chatgpt.com/codex/tasks/task_e_6842e9a8b260832f90424bce1513c5ad