### PR TITLE
Fix action push by enabling write permissions

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '0 3 * * 1'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- grant the GitHub action contents write permission

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6842eb286048832f9ea5eba19493a54d