### PR TITLE
Update README for Node 20 and repo path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Dieses Projekt extrahiert Karten aus dem Bereich **Pokémon TCG Pocket** des Open-Source-Repositories [tcgdex/cards-database](https://github.com/tcgdex/cards-database) und stellt sie als JSON bereit. Das JSON wird für weitere Projekte wie Discord-Bots oder mobile Apps genutzt.
 
+## Voraussetzungen
+
+- Benötigt wird **Node.js 20** (siehe GitHub Action)
+
 ## Projektüberblick
 
 - **Quelle**: Unter `tcgdex/data/Pokémon TCG Pocket/` befinden sich Set-Dateien und Karten-Dateien (.ts)
@@ -17,6 +21,9 @@ Dieses Projekt extrahiert Karten aus dem Bereich **Pokémon TCG Pocket** des Ope
    ```bash
    git clone https://github.com/tcgdex/cards-database tcgdex
    ```
+   Das Skript erwartet standardmäßig einen Ordner `tcgdex` im Projektverzeichnis. 
+   Falls du einen anderen Pfad verwendest, kannst du ihn über die Umgebungsvariable 
+   `TCGDEX_DIR` oder beim Aufruf mit `--tcgdex <pfad>` angeben.
 3. Abhängigkeiten installieren und Export starten:
    ```bash
    npm install

--- a/src/export.ts
+++ b/src/export.ts
@@ -2,9 +2,20 @@ import fs from "fs-extra";
 import path from "path";
 import { glob } from "glob";
 
+// Standard-Ordner für das tcgdex-Repo kann über Env oder CLI angepasst werden
+function getArg(flag: string): string | undefined {
+  const index = process.argv.indexOf(flag);
+  if (index !== -1 && process.argv[index + 1]) {
+    return process.argv[index + 1];
+  }
+  return undefined;
+}
+
+const repoDir = getArg("--tcgdex") || process.env.TCGDEX_DIR || "tcgdex";
+
 // 1. Alle Set-Dateien einlesen
-const SETS_GLOB = "tcgdex/data/Pokémon TCG Pocket/*.ts";
-const CARDS_GLOB = "tcgdex/data/Pokémon TCG Pocket/*/*.ts";
+const SETS_GLOB = path.join(repoDir, "data", "Pokémon TCG Pocket", "*.ts");
+const CARDS_GLOB = path.join(repoDir, "data", "Pokémon TCG Pocket", "*", "*.ts");
 
 // Hilfsfunktion, um dynamisch zu importieren (require)
 function importTSFile(file: string) {


### PR DESCRIPTION
## Summary
- document Node.js 20 requirement
- explain how to override tcgdex repo location
- allow tcgdex path via env var or CLI flag

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_6842f0675380832fb5edaab1f180dc00