### PR TITLE
Update workflow to build before export

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -34,8 +34,11 @@ jobs:
         run: npm install
         # Hier KEIN working-directory nötig, default ist das Hauptrepo!
 
+      - name: Build
+        run: npm run build
+
       - name: Run export script
-        run: npx ts-node src/export.ts
+        run: npm run export
         # Hier KEIN working-directory nötig, default ist das Hauptrepo!
 
       - name: Commit and push changes


### PR DESCRIPTION
## Summary
- run `npm run build` before exporting
- execute `npm run export` instead of `ts-node`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843122a1500832fb0684f1ce4179010