### PR TITLE
Fix runtime import of TS modules

### DIFF
--- a/src/export.ts
+++ b/src/export.ts
@@ -1,3 +1,4 @@
+import 'ts-node/register';
 import fs from 'fs-extra';
 import path from 'path';
 import { glob } from 'glob';


### PR DESCRIPTION
## Summary
- register ts-node so Node can import .ts card files
- keep build artifacts out of Git

## Testing
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run export`

------
https://chatgpt.com/codex/tasks/task_e_684368533b98832f97ae28e8dd86e34c