### PR TITLE
Fix TypeScript build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,24 +12,23 @@
   },
   "dependencies": {
     "fs-extra": "^11.2.0",
-    "glob": "^10.3.10",
-    "node-fetch": "^3.3.2"
+    "glob": "^10.3.10"
   },
   "devDependencies": {
-    "typescript": "^5.4.5",
-    "ts-node": "^10.9.2",
-    "@types/node": "^20.11.30",
-    "@types/fs-extra": "^11.0.4",
-    "eslint": "^8.56.0",
     "@eslint/js": "^9.28.0",
-    "@typescript-eslint/parser": "^6.21.0",
+    "@types/fs-extra": "^11.0.4",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.11.30",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
-    "prettier": "^3.2.5",
+    "@typescript-eslint/parser": "^6.21.0",
+    "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "jest": "^29.7.0",
+    "prettier": "^3.2.5",
     "ts-jest": "^29.1.1",
-    "@types/jest": "^29.5.12"
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
   },
   "repository": {
     "type": "git",

--- a/src/export.ts
+++ b/src/export.ts
@@ -2,7 +2,6 @@ import 'ts-node/register';
 import fs from 'fs-extra';
 import path from 'path';
 import { glob } from 'glob';
-import fetch from 'node-fetch';
 
 interface SetInfo {
   id: string;
@@ -18,14 +17,25 @@ interface Card {
   [key: string]: any;
 }
 
+// Struktur der datas.json Datei
+export interface DatasJson {
+  [lang: string]: {
+    [serieId: string]: {
+      [setId: string]: {
+        [cardId: string]: string[];
+      };
+    };
+  };
+}
+
 // Hilfsfunktion, um datas.json von tcgdex zu laden
-async function fetchDatasJson() {
+async function fetchDatasJson(): Promise<DatasJson> {
   const url = 'https://assets.tcgdex.net/datas.json';
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error('Failed to fetch datas.json');
   }
-  return await res.json();
+  return (await res.json()) as DatasJson;
 }
 
 // Standard-Ordner für das tcgdex-Repo kann über Env oder CLI angepasst werden
@@ -79,8 +89,6 @@ async function main() {
 
   // Schritt 2: Sets einlesen
   const sets = await getAllSets();
-  // Map zur schnellen Suche nach Set nach ID
-  const setMap = new Map(sets.map(s => [s.id, s]));
 
   // Schritt 3: Karten einlesen und um Set-ID ergänzen
   const files = await glob(CARDS_GLOB);
@@ -92,7 +100,7 @@ async function main() {
     const mod = await importTSFile(file);
     const card = mod.default || mod;
 
-    let setId: string | undefined = undefined;
+    let setId: string;
     if (card.set && card.set.id) {
       setId = card.set.id;
     } else {
@@ -124,7 +132,8 @@ async function main() {
         // Verfügbare Qualitäten holen (["high", "medium", ...])
         const qualities = datas[lang][serieId][setId][cardId];
         for (const quality of qualities) {
-          card.images[lang][quality] = `https://assets.tcgdex.net/${lang}/${serieId}/${setId}/${cardId}/${quality}.webp`;
+          card.images[lang][quality] =
+            `https://assets.tcgdex.net/${lang}/${serieId}/${setId}/${cardId}/${quality}.webp`;
         }
       }
     }


### PR DESCRIPTION
## Summary
- define `DatasJson` interface and use in export script
- type returned data in tests
- drop `node-fetch` dependency and rely on the Node 20 built‑in `fetch`

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: process.exit called during test execution)*

------
https://chatgpt.com/codex/tasks/task_e_6844d6b10a74832f8e09ad5a19097f27