### PR TITLE
Fix docs for sets export and update workflow

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -45,5 +45,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "Automated data extraction"
-          file_pattern: data/cards.json
+          file_pattern: |
+            data/cards.json
+            data/sets.json
         # Hier KEIN working-directory möglich!

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Dieses Projekt extrahiert Karten aus dem Bereich **Pokémon TCG Pocket** des Ope
 ## Projektüberblick
 
 - **Quelle**: Unter `tcgdex/data/Pokémon TCG Pocket/` befinden sich Set-Dateien und Karten-Dateien (.ts)
-- **Skript**: `src/export.ts` liest die Dateien und erzeugt `data/cards.json` im Format `{ sets: [...], cards: [...] }`.
+- **Skript**: `src/export.ts` liest die Dateien und erzeugt zwei Dateien: `data/cards.json` und `data/sets.json`.
 - **Automatisierung**: 
   - Mit GitHub Actions wird bei jedem Push, per Button und wöchentlich ein Workflow ausgeführt.
   - Der Workflow klont `tcgdex/cards-database`, führt das Skript aus und committet das aktualisierte JSON zurück.
@@ -32,7 +32,9 @@ Dieses Projekt extrahiert Karten aus dem Bereich **Pokémon TCG Pocket** des Ope
    npm run build
    npm run export
    ```
-4. Das Ergebnis liegt in `data/cards.json` und enthält sowohl Sets als auch Karten.
+4. Das Ergebnis landet in zwei Dateien:
+   - `data/cards.json` mit allen Karten
+   - `data/sets.json` mit den Set-Informationen
 
 ## Codequalität prüfen
 

--- a/docs/json-format.md
+++ b/docs/json-format.md
@@ -1,16 +1,12 @@
 
-# Format von `data/cards.json`
+# Format der JSON-Dateien
 
-Das JSON wird durch das Skript `src/export.ts` erzeugt. Seit der Umstellung enthält die Datei ein Objekt mit zwei Bereichen:
+Das Skript `src/export.ts` erzeugt zwei Dateien im Verzeichnis `data/`:
 
-```json
-{
-  "sets": [...],
-  "cards": [...]
-}
-```
+- **`cards.json`** – enthält eine Liste aller Karten.
+- **`sets.json`** – enthält Informationen zu allen Sets bzw. Boostern.
 
-`sets` beschreibt die Boosterpacks beziehungsweise Set-Informationen. `cards` ist eine Liste aller Karten. Die beiden Bereiche sind voneinander getrennt, sodass Anwendungen bei Bedarf nur einen Teil einlesen können.
+Beide Dateien liegen als Arrays vor, sodass sie unabhängig voneinander eingelesen werden können.
 
 ## Karten
 


### PR DESCRIPTION
## Summary
- commit sets.json in the workflow
- document that export.ts writes cards.json and sets.json separately
- update JSON format documentation

## Testing
- `npm run build`
- `npm run lint` *(fails: Unexpected any)*
- `npm test` *(fails: network fetch)*

------
https://chatgpt.com/codex/tasks/task_e_68454b2acc4c832fb2f85f25d22c269b