### PR TITLE
Fix export path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,6 @@
 # Hinweise für Agents
 
 - Benötigt wird Node.js 20.
-- Über die Umgebungsvariable `TCGDEX_DIR` lässt sich der Pfad zum Klon von `tcgdex/cards-database` festlegen.
 - Daten unter `data/pers/` (falls vorhanden) sollen nicht versioniert werden.
 - Optional können einfache Tests wie `npm test` ausgeführt werden.
 - Aktualisiere die Dokumentation, wenn sich Funktionen oder Verhalten 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Vielen Dank für dein Interesse an diesem Projekt. Bitte beachte beim Arbeiten d
 ## Voraussetzungen
 
 - Installiere **Node.js 20**.
-- Klone das Fremd-Repository [`tcgdex/cards-database`](https://github.com/tcgdex/cards-database) in einen Ordner `tcgdex` im Projektverzeichnis **oder** lege den Pfad über die Umgebungsvariable `TCGDEX_DIR` fest.
+- Klone das Fremd-Repository [`tcgdex/cards-database`](https://github.com/tcgdex/cards-database) in einen Ordner `tcgdex` im Projektverzeichnis.
 
 ## Abläufe
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ Dieses Projekt extrahiert Karten aus dem Bereich **Pokémon TCG Pocket** des Ope
    ```bash
    git clone https://github.com/tcgdex/cards-database tcgdex
    ```
-   Das Skript erwartet standardmäßig einen Ordner `tcgdex` im Projektverzeichnis. 
-   Falls du einen anderen Pfad verwendest, kannst du ihn über die Umgebungsvariable 
-   `TCGDEX_DIR` oder beim Aufruf mit `--tcgdex <pfad>` angeben.
+   Das Skript erwartet einen Ordner `tcgdex` im Projektverzeichnis.
 3. Abhängigkeiten installieren, Build erzeugen und Export starten:
    ```bash
    npm install

--- a/src/export.ts
+++ b/src/export.ts
@@ -6,24 +6,16 @@ import { glob } from 'glob';
 // Typdefinitionen
 interface SetInfo {
   id: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 interface Card {
   set_id?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
-// Standard-Ordner für das tcgdex-Repo kann über Env oder CLI angepasst werden
-function getArg(flag: string): string | undefined {
-  const index = process.argv.indexOf(flag);
-  if (index !== -1 && process.argv[index + 1]) {
-    return process.argv[index + 1];
-  }
-  return undefined;
-}
-
-const repoDir = getArg('--tcgdex') || process.env.TCGDEX_DIR || 'tcgdex';
+// Standard-Ordner für das tcgdex-Repo
+const repoDir = path.resolve('tcgdex');
 
 const SETS_GLOB = path.join(repoDir, 'data', 'Pokémon TCG Pocket', '*.ts');
 const CARDS_GLOB = path.join(

--- a/test/export.test.ts
+++ b/test/export.test.ts
@@ -37,16 +37,8 @@ async function fetchDatasJson(): Promise<DatasJson> {
   return (await res.json()) as DatasJson;
 }
 
-// Standard-Ordner für das tcgdex-Repo kann über Env oder CLI angepasst werden
-function getArg(flag: string): string | undefined {
-  const index = process.argv.indexOf(flag);
-  if (index !== -1 && process.argv[index + 1]) {
-    return process.argv[index + 1];
-  }
-  return undefined;
-}
-
-const repoDir = getArg('--tcgdex') || process.env.TCGDEX_DIR || 'tcgdex';
+// Standard-Ordner für das tcgdex-Repo
+const repoDir = path.resolve('tcgdex');
 
 const SETS_GLOB = path.join(repoDir, 'data', 'Pokémon TCG Pocket', '*.ts');
 const CARDS_GLOB = path.join(


### PR DESCRIPTION
## Summary
- use a fixed `tcgdex` directory instead of checking CLI/env variables
- keep TypeScript types strict
- document the fixed path setup in README and CONTRIBUTING
- remove obsolete instructions from AGENTS

## Testing
- `npm run build`
- `npm run lint`
- `npm test` *(fails: fetch fails, process exit)*

------
https://chatgpt.com/codex/tasks/task_e_684554ed8e74832f917ff490b62a302e