### PR TITLE
Check for tcgdex repo before exporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,17 @@ Dieses Projekt extrahiert Karten aus dem Bereich **Pokémon TCG Pocket** des Ope
 ## Voraussetzungen
 
 - Benötigt wird **Node.js 20** (siehe GitHub Action)
-- Bitte aktualisiere die Dokumentation, wenn sich Funktionen oder Verhalten 
+- Bitte aktualisiere die Dokumentation, wenn sich Funktionen oder Verhalten
   ändern.
+- Vor dem Export muss ein Klon von `tcgdex/cards-database` im Unterordner
+  `tcgdex` vorhanden sein. Fehlt das Verzeichnis, beendet das Skript den Vorgang
+  mit einer Fehlermeldung.
 
 ## Projektüberblick
 
 - **Quelle**: Unter `tcgdex/data/Pokémon TCG Pocket/` befinden sich Set-Dateien und Karten-Dateien (.ts)
 - **Skript**: `src/export.ts` liest die Dateien und erzeugt zwei Dateien: `data/cards.json` und `data/sets.json`.
-- **Automatisierung**: 
+- **Automatisierung**:
   - Mit GitHub Actions wird bei jedem Push, per Button und wöchentlich ein Workflow ausgeführt.
   - Der Workflow klont `tcgdex/cards-database`, führt das Skript aus und committet das aktualisierte JSON zurück.
 
@@ -23,7 +26,8 @@ Dieses Projekt extrahiert Karten aus dem Bereich **Pokémon TCG Pocket** des Ope
    ```bash
    git clone https://github.com/tcgdex/cards-database tcgdex
    ```
-   Das Skript erwartet einen Ordner `tcgdex` im Projektverzeichnis.
+   Das Skript erwartet einen Ordner `tcgdex` im Projektverzeichnis. Fehlt er,
+   schlägt `npm run export` mit einer Fehlermeldung fehl.
 3. Abhängigkeiten installieren, Build erzeugen und Export starten:
    ```bash
    npm install
@@ -59,4 +63,3 @@ Dieses Projekt steht unter der [MIT-Lizenz](LICENSE). Es nutzt Daten aus
 [tcgdex/cards-database](https://github.com/tcgdex/cards-database), das ebenfalls
 unter der [MIT-Lizenz](https://github.com/tcgdex/cards-database/blob/master/LICENSE)
 veröffentlicht wird.
-

--- a/src/export.ts
+++ b/src/export.ts
@@ -17,6 +17,15 @@ interface Card {
 // Standard-Ordner für das tcgdex-Repo
 const repoDir = path.resolve('tcgdex');
 
+async function ensureRepoDir() {
+  if (!(await fs.pathExists(repoDir))) {
+    console.error(
+      `Repo directory '${repoDir}' not found. Clone tcgdex/cards-database into this folder.`,
+    );
+    process.exit(1);
+  }
+}
+
 const SETS_GLOB = path.join(repoDir, 'data', 'Pokémon TCG Pocket', '*.ts');
 const CARDS_GLOB = path.join(
   repoDir,
@@ -74,6 +83,7 @@ async function getAllCards(): Promise<Card[]> {
 }
 
 async function main() {
+  await ensureRepoDir();
   // Schritt 1: Sets einlesen
   const sets = await getAllSets();
 

--- a/test/export.test.ts
+++ b/test/export.test.ts
@@ -40,6 +40,14 @@ async function fetchDatasJson(): Promise<DatasJson> {
 // Standard-Ordner für das tcgdex-Repo
 const repoDir = path.resolve('tcgdex');
 
+async function ensureRepoDir(): Promise<boolean> {
+  if (!(await fs.pathExists(repoDir))) {
+    console.log('Skipping export test: repo directory not found');
+    return false;
+  }
+  return true;
+}
+
 const SETS_GLOB = path.join(repoDir, 'data', 'Pokémon TCG Pocket', '*.ts');
 const CARDS_GLOB = path.join(
   repoDir,
@@ -71,6 +79,9 @@ async function getAllSets() {
 
 // Main-Funktion
 async function main() {
+  if (!(await ensureRepoDir())) {
+    return;
+  }
   // Schritt 1: Bilddaten laden
   console.log('Lade datas.json von tcgdex...');
   const datas = await fetchDatasJson();
@@ -146,7 +157,9 @@ async function main() {
   );
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
+test('run export script', async () => {
+  if (!(await ensureRepoDir())) {
+    return;
+  }
+  await main();
 });


### PR DESCRIPTION
## Summary
- abort export if `tcgdex` repo is missing
- skip export test if repo dir isn't found
- describe the required `tcgdex` folder in the docs

## Testing
- `npm run lint --silent`
- `npm run build --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684568b25c54832fab5e7a7fe7061859