### PR TITLE
Add tcgdex to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ data/pers/
 
 # Jest coverage output
 coverage/
+
+# Local clone of tcgdex/cards-database
+tcgdex/


### PR DESCRIPTION
## Summary
- ignore the local clone of tcgdex/cards-database

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859cfebcb40832f8bd63dd613751e07