### PR TITLE
Update docs about serie field omission

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Dieses Projekt extrahiert Karten aus dem Bereich **Pokémon TCG Pocket** des Ope
 
 - **Quelle**: Unter `tcgdex/data/Pokémon TCG Pocket/` befinden sich Set-Dateien und Karten-Dateien (.ts)
 - **Skript**: `src/export.ts` liest die Dateien und erzeugt zwei Dateien: `data/cards.json` und `data/sets.json`.
+  Das `serie`-Feld aus den tcgdex-Set-Dateien wird dabei nicht in `sets.json` 
+  übernommen.
 - **Automatisierung**:
   - Mit GitHub Actions wird bei jedem Push, per Button und wöchentlich ein Workflow ausgeführt.
   - Der Workflow klont `tcgdex/cards-database`, führt das Skript aus und committet das aktualisierte JSON zurück.

--- a/docs/json-format.md
+++ b/docs/json-format.md
@@ -25,6 +25,7 @@ Die genaue Struktur kann je nach Karte variieren, da auch Attacken, Fähigkeiten
 ## Packs
 
 Im Abschnitt `sets` finden sich Informationen zu jedem Boosterpack beziehungsweise Kartenset. Die Objekte werden über ihre ID angesprochen und enthalten Namen in mehreren Sprachen sowie Zusatzinformationen wie `releaseDate` oder `cardCount`. Innerhalb eines Sets gibt es zudem die Auflistung `boosters`, die die unterschiedlichen Pack-Varianten beschreibt.
+Dabei wird das `serie`-Feld aus den tcgdex-Set-Dateien bewusst entfernt, da es für die Pocket-Daten keine Relevanz hat.
 
 Ein minimales Pack-Objekt sieht so aus:
 


### PR DESCRIPTION
## Summary
- document that the `serie` property from tcgdex sets is removed from the JSON output

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859d00425f0832faf8174802e319390