### PR TITLE
Add Node version check and test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,8 @@ Vielen Dank für dein Interesse an diesem Projekt. Bitte beachte beim Arbeiten d
 ## Voraussetzungen
 
 - Installiere **Node.js 20**.
+- Das Export-Skript prüft die Node-Version und beendet sich bei Abweichungen
+  mit einer Fehlermeldung.
 - Klone das Fremd-Repository [`tcgdex/cards-database`](https://github.com/tcgdex/cards-database) in einen Ordner `tcgdex` im Projektverzeichnis.
 
 ## Abläufe

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Dieses Projekt extrahiert Karten aus dem Bereich **Pokémon TCG Pocket** des Ope
 ## Voraussetzungen
 
 - Benötigt wird **Node.js 20** (siehe GitHub Action)
+- Das Export-Skript prüft die Node.js-Version und bricht bei Abweichungen
+  mit einer Fehlermeldung ab.
 - Bitte aktualisiere die Dokumentation, wenn sich Funktionen oder Verhalten
   ändern.
 - Vor dem Export muss ein Klon von `tcgdex/cards-database` im Unterordner

--- a/src/export.ts
+++ b/src/export.ts
@@ -17,6 +17,17 @@ interface Card {
 // Standard-Ordner für das tcgdex-Repo
 const repoDir = path.resolve('tcgdex');
 
+export function checkNodeVersion(
+  version: string = process.versions.node,
+  requiredMajor = 20,
+) {
+  const major = parseInt(version.split('.')[0], 10);
+  if (major !== requiredMajor) {
+    console.error(`Node.js ${requiredMajor} is required. Detected ${version}.`);
+    process.exit(1);
+  }
+}
+
 async function ensureRepoDir() {
   if (!(await fs.pathExists(repoDir))) {
     console.error(
@@ -83,6 +94,7 @@ async function getAllCards(): Promise<Card[]> {
 }
 
 async function main() {
+  checkNodeVersion();
   await ensureRepoDir();
   // Schritt 1: Sets einlesen
   const sets = await getAllSets();
@@ -113,7 +125,9 @@ async function main() {
   );
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/test/node-version.test.ts
+++ b/test/node-version.test.ts
@@ -1,0 +1,18 @@
+import { checkNodeVersion } from '../src/export';
+
+describe('checkNodeVersion', () => {
+  it('exits when node version is not 20', () => {
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => checkNodeVersion('18.0.0')).toThrow('exit');
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Node.js 20'),
+    );
+
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- exit if Node.js major version is not 20
- document runtime version check
- avoid running export script when imported
- test version check logic

## Testing
- `npm run build`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859d0371f40832fae508a108159ee1b