### PR TITLE
Improve import speed with Promise.all

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Dieses Projekt extrahiert Karten aus dem Bereich **Pokémon TCG Pocket** des Ope
 
 - **Quelle**: Unter `tcgdex/data/Pokémon TCG Pocket/` befinden sich Set-Dateien und Karten-Dateien (.ts)
 - **Skript**: `src/export.ts` liest die Dateien und erzeugt zwei Dateien: `data/cards.json` und `data/sets.json`.
+  Seit Version 1.1 werden die Dateien parallel importiert, was den Export deutlich beschleunigt.
 - **Automatisierung**:
   - Mit GitHub Actions wird bei jedem Push, per Button und wöchentlich ein Workflow ausgeführt.
   - Der Workflow klont `tcgdex/cards-database`, führt das Skript aus und committet das aktualisierte JSON zurück.

--- a/docs/json-format.md
+++ b/docs/json-format.md
@@ -6,7 +6,7 @@ Das Skript `src/export.ts` erzeugt zwei Dateien im Verzeichnis `data/`:
 - **`cards.json`** – enthält eine Liste aller Karten.
 - **`sets.json`** – enthält Informationen zu allen Sets bzw. Boostern.
 
-Beide Dateien liegen als Arrays vor, sodass sie unabhängig voneinander eingelesen werden können.
+Beide Dateien liegen als Arrays vor, sodass sie unabhängig voneinander eingelesen werden können. Seit Version 1.1 werden die Quelldateien parallel eingelesen, was die Ausführung beschleunigt.
 
 ## Karten
 

--- a/src/export.ts
+++ b/src/export.ts
@@ -42,43 +42,45 @@ async function importTSFile(file: string) {
 
 async function getAllSets(): Promise<SetInfo[]> {
   const setFiles = await glob(SETS_GLOB);
-  const sets: SetInfo[] = [];
 
-  for (const file of setFiles) {
-    const set = (await importTSFile(file)).default;
-    // Entferne das "serie"-Feld!
-    if (set.serie) {
-      delete set.serie;
-    }
-    if (!set.name) {
-      set.name = { en: path.basename(file, '.ts') };
-    }
-    sets.push(set);
-  }
+  const sets = await Promise.all(
+    setFiles.map(async (file) => {
+      const set = (await importTSFile(file)).default;
+      // Entferne das "serie"-Feld!
+      if (set.serie) {
+        delete set.serie;
+      }
+      if (!set.name) {
+        set.name = { en: path.basename(file, '.ts') };
+      }
+      return set;
+    }),
+  );
   return sets;
 }
 
 async function getAllCards(): Promise<Card[]> {
   const files = await glob(CARDS_GLOB);
-  const cards: Card[] = [];
 
-  for (const file of files) {
-    const mod = await importTSFile(file);
-    const card = mod.default || mod;
+  const cards = await Promise.all(
+    files.map(async (file) => {
+      const mod = await importTSFile(file);
+      const card = mod.default || mod;
 
-    let setId: string;
-    if (card.set && card.set.id) {
-      setId = card.set.id;
-    } else {
-      setId = path.basename(path.dirname(file));
-    }
-    card.set_id = setId;
+      let setId: string;
+      if (card.set && card.set.id) {
+        setId = card.set.id;
+      } else {
+        setId = path.basename(path.dirname(file));
+      }
+      card.set_id = setId;
 
-    // Entferne das Set-Objekt komplett aus der Karte!
-    delete card.set;
+      // Entferne das Set-Objekt komplett aus der Karte!
+      delete card.set;
 
-    cards.push(card);
-  }
+      return card;
+    }),
+  );
   return cards;
 }
 

--- a/test/export.test.ts
+++ b/test/export.test.ts
@@ -42,17 +42,18 @@ async function importTSFile(file: string) {
   return await import(pathToFile);
 }
 
-async function getAllSets() {
+async function getAllSets(): Promise<SetInfo[]> {
   const setFiles = await glob(SETS_GLOB);
-  const sets: SetInfo[] = [];
 
-  for (const file of setFiles) {
-    const set = (await importTSFile(file)).default;
-    if (!set.name) {
-      set.name = { en: path.basename(file, '.ts') };
-    }
-    sets.push(set);
-  }
+  const sets = await Promise.all(
+    setFiles.map(async (file) => {
+      const set = (await importTSFile(file)).default;
+      if (!set.name) {
+        set.name = { en: path.basename(file, '.ts') };
+      }
+      return set;
+    }),
+  );
   return sets;
 }
 
@@ -68,21 +69,21 @@ async function main() {
   const files = await glob(CARDS_GLOB);
   console.log('Files found:', files.length);
 
-  const cards: Card[] = [];
+  const cards: Card[] = await Promise.all(
+    files.map(async (file) => {
+      const mod = await importTSFile(file);
+      const card = mod.default || mod;
 
-  for (const file of files) {
-    const mod = await importTSFile(file);
-    const card = mod.default || mod;
-
-    let setId: string;
-    if (card.set && card.set.id) {
-      setId = card.set.id;
-    } else {
-      setId = path.basename(path.dirname(file));
-    }
-    card.set_id = setId;
-    cards.push(card);
-  }
+      let setId: string;
+      if (card.set && card.set.id) {
+        setId = card.set.id;
+      } else {
+        setId = path.basename(path.dirname(file));
+      }
+      card.set_id = setId;
+      return card;
+    }),
+  );
 
   // Schritt 4: Schreibe Karten und Sets in getrennte Dateien
   const dataDir = path.join(__dirname, '..', 'data');


### PR DESCRIPTION
## Summary
- load all card and set files in parallel
- ensure tests mirror new async logic
- document faster import

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859d039bc30832f84baaa4d07d442ab