### PR TITLE
Allow Node.js 20+

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 20.x
 
       - name: Install dependencies
         run: npm install
@@ -44,6 +44,6 @@ jobs:
       - name: Commit and push changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "Automated data extraction"
+          commit_message: 'Automated data extraction'
           file_pattern: 'data/cards.json data/sets.json'
         # Hier KEIN working-directory möglich!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+- Allow running on Node.js 20 or newer.
+- Updated documentation and tests.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Dieses Projekt extrahiert Karten aus dem Bereich **Pokémon TCG Pocket** des Ope
 
 ## Voraussetzungen
 
-- Benötigt wird **Node.js 20** (siehe GitHub Action)
-- Das Export-Skript prüft die Node.js-Version und bricht bei Abweichungen
-  mit einer Fehlermeldung ab.
+- Benötigt wird **Node.js 20 oder neuer** (siehe GitHub Action)
+- Das Export-Skript prüft die Node.js-Version und bricht bei zu niedrigen
+  Versionen mit einer Fehlermeldung ab.
 - Bitte aktualisiere die Dokumentation, wenn sich Funktionen oder Verhalten
   ändern.
 - Vor dem Export muss ein Klon von `tcgdex/cards-database` im Unterordner
@@ -18,7 +18,7 @@ Dieses Projekt extrahiert Karten aus dem Bereich **Pokémon TCG Pocket** des Ope
 - **Quelle**: Unter `tcgdex/data/Pokémon TCG Pocket/` befinden sich Set-Dateien und Karten-Dateien (.ts)
 - **Skript**: `src/export.ts` liest die Dateien und erzeugt zwei Dateien: `data/cards.json` und `data/sets.json`.
   Seit Version 1.1 werden die Dateien parallel importiert, was den Export deutlich beschleunigt.
-  Das `serie`-Feld aus den tcgdex-Set-Dateien wird dabei nicht in `sets.json` 
+  Das `serie`-Feld aus den tcgdex-Set-Dateien wird dabei nicht in `sets.json`
   übernommen.
 - **Automatisierung**:
   - Mit GitHub Actions wird bei jedem Push, per Button und wöchentlich ein Workflow ausgeführt.

--- a/test/node-version.test.ts
+++ b/test/node-version.test.ts
@@ -1,7 +1,7 @@
 import { checkNodeVersion } from '../src/export';
 
 describe('checkNodeVersion', () => {
-  it('exits when node version is not 20', () => {
+  it('exits when node major version is below 20', () => {
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('exit');
     });
@@ -9,10 +9,20 @@ describe('checkNodeVersion', () => {
 
     expect(() => checkNodeVersion('18.0.0')).toThrow('exit');
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Node.js 20'),
+      expect.stringContaining('Node.js 20+'),
     );
 
     exitSpy.mockRestore();
     errorSpy.mockRestore();
+  });
+
+  it('does not exit when node version is higher', () => {
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+
+    expect(() => checkNodeVersion('21.0.0')).not.toThrow();
+
+    exitSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- relax Node version check to allow Node 20+
- update workflow to use Node `20.x`
- document Node requirement and add CHANGELOG
- add docstrings for major functions
- extend node version tests

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a7f8fd1cc832fba04eafa0f2a60ca