### PR TITLE
Improve export validation and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,6 @@ All notable changes to this project will be documented in this file.
 
 - Allow running on Node.js 20 or newer.
 - Updated documentation and tests.
+- Improved path validation and error handling in export script.
+- Export script now throws errors instead of exiting directly.
+- Added security note in README.

--- a/README.md
+++ b/README.md
@@ -34,14 +34,22 @@ Dieses Projekt extrahiert Karten aus dem Bereich **Pokémon TCG Pocket** des Ope
    Das Skript erwartet einen Ordner `tcgdex` im Projektverzeichnis. Fehlt er,
    schlägt `npm run export` mit einer Fehlermeldung fehl.
 3. Abhängigkeiten installieren, Build erzeugen und Export starten:
+
    ```bash
    npm install
    npm run build
    npm run export
    ```
+
 4. Das Ergebnis landet in zwei Dateien:
    - `data/cards.json` mit allen Karten
    - `data/sets.json` mit den Set-Informationen
+
+## Sicherheitshinweis
+
+Das Skript importiert TypeScript-Dateien aus dem externen Repository
+`tcgdex/cards-database` und führt deren Code aus. Stelle sicher, dass du diesem
+Repository vertraust oder den Inhalt prüfst, bevor du den Export ausführst.
 
 ## Codequalität prüfen
 

--- a/test/export.test.ts
+++ b/test/export.test.ts
@@ -1,114 +1,37 @@
 import 'ts-node/register';
 import fs from 'fs-extra';
 import path from 'path';
-import { glob } from 'glob';
 
-interface SetInfo {
-  id: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
+async function repoExists(repoDir: string): Promise<boolean> {
+  return fs.pathExists(repoDir);
 }
 
-interface Card {
-  set_id?: string;
-  // additional card information
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
-}
+describe('export script', () => {
+  const dataDir = path.resolve('data');
 
-// Standard-Ordner für das tcgdex-Repo
-const repoDir = path.resolve('tcgdex');
+  it('runs export when repo present', async () => {
+    const defaultRepo = path.resolve('tcgdex');
+    if (!(await repoExists(defaultRepo))) {
+      console.log('Skipping export test: repo directory not found');
+      return;
+    }
+    jest.resetModules();
+    delete process.env.TCGDEX_REPO;
+    const { main } = await import('../src/export');
+    await main();
+    await expect(fs.pathExists(path.join(dataDir, 'cards.json'))).resolves.toBe(
+      true,
+    );
+    await expect(fs.pathExists(path.join(dataDir, 'sets.json'))).resolves.toBe(
+      true,
+    );
+  });
 
-async function ensureRepoDir(): Promise<boolean> {
-  if (!(await fs.pathExists(repoDir))) {
-    console.log('Skipping export test: repo directory not found');
-    return false;
-  }
-  return true;
-}
-
-const SETS_GLOB = path.join(repoDir, 'data', 'Pokémon TCG Pocket', '*.ts');
-const CARDS_GLOB = path.join(
-  repoDir,
-  'data',
-  'Pokémon TCG Pocket',
-  '*',
-  '*.ts',
-);
-
-// Hilfsfunktion, um dynamisch zu importieren
-async function importTSFile(file: string) {
-  const pathToFile = path.resolve(file);
-  return await import(pathToFile);
-}
-
-async function getAllSets(): Promise<SetInfo[]> {
-  const setFiles = await glob(SETS_GLOB);
-
-  const sets = await Promise.all(
-    setFiles.map(async (file) => {
-      const set = (await importTSFile(file)).default;
-      if (!set.name) {
-        set.name = { en: path.basename(file, '.ts') };
-      }
-      return set;
-    }),
-  );
-  return sets;
-}
-
-// Main-Funktion
-async function main() {
-  if (!(await ensureRepoDir())) {
-    return;
-  }
-  // Sets einlesen
-  const sets = await getAllSets();
-
-  // Schritt 3: Karten einlesen und um Set-ID ergänzen
-  const files = await glob(CARDS_GLOB);
-  console.log('Files found:', files.length);
-
-  const cards: Card[] = await Promise.all(
-    files.map(async (file) => {
-      const mod = await importTSFile(file);
-      const card = mod.default || mod;
-
-      let setId: string;
-      if (card.set && card.set.id) {
-        setId = card.set.id;
-      } else {
-        setId = path.basename(path.dirname(file));
-      }
-      card.set_id = setId;
-      return card;
-    }),
-  );
-
-  // Schritt 4: Schreibe Karten und Sets in getrennte Dateien
-  const dataDir = path.join(__dirname, '..', 'data');
-  await fs.ensureDir(dataDir);
-
-  const cardsOutPath = path.join(dataDir, 'cards.json');
-  const setsOutPath = path.join(dataDir, 'sets.json');
-
-  await fs.writeJson(cardsOutPath, cards, { spaces: 2 });
-  await fs.writeJson(setsOutPath, sets, { spaces: 2 });
-
-  // Debug-Ausgabe
-  if (process.env.DEBUG) {
-    const outRaw = await fs.readFile(cardsOutPath, 'utf-8');
-    console.log('Erste 500 Zeichen aus cards.json:\n', outRaw.slice(0, 500));
-  }
-
-  console.log(
-    `Exported ${cards.length} cards to data/cards.json and ${sets.length} sets to data/sets.json`,
-  );
-}
-
-test('run export script', async () => {
-  if (!(await ensureRepoDir())) {
-    return;
-  }
-  await main();
+  it('fails with invalid repo path', async () => {
+    jest.resetModules();
+    process.env.TCGDEX_REPO = '__invalid__';
+    const { main } = await import('../src/export');
+    await expect(main()).rejects.toThrow(/Repo directory/);
+    delete process.env.TCGDEX_REPO;
+  });
 });


### PR DESCRIPTION
## Summary
- validate import paths to stay within tcgdex directory
- throw errors instead of exiting when repo directory is missing
- wrap set/card import logic in try/catch with descriptive errors
- export the `main` function and use it in tests
- add security note about executing external code
- update CHANGELOG

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a8605bd98832fae30f5c2a5b0fe60