### PR TITLE
Refactor export logic into library module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,5 @@ All notable changes to this project will be documented in this file.
 - Updated documentation and tests.
 - Improved path validation and error handling in export script.
 - Export script now throws errors instead of exiting directly.
+- Added concurrency limit for loading files and split library code into `src/lib.ts`.
 - Added security note in README.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ Dieses Projekt extrahiert Karten aus dem Bereich **Pokémon TCG Pocket** des Ope
 ## Projektüberblick
 
 - **Quelle**: Unter `tcgdex/data/Pokémon TCG Pocket/` befinden sich Set-Dateien und Karten-Dateien (.ts)
-- **Skript**: `src/export.ts` liest die Dateien und erzeugt zwei Dateien: `data/cards.json` und `data/sets.json`.
-  Seit Version 1.1 werden die Dateien parallel importiert, was den Export deutlich beschleunigt.
+- **Skript**: `src/export.ts` dient als CLI und nutzt Funktionen aus `src/lib.ts`,
+  um die Daten zu sammeln und zu schreiben.
+  Die Dateien werden mit begrenzter Parallelität (Standard: 10 gleichzeitig) eingelesen,
+  was eine gute Balance zwischen Geschwindigkeit und Stabilität bietet.
   Das `serie`-Feld aus den tcgdex-Set-Dateien wird dabei nicht in `sets.json`
   übernommen.
 - **Automatisierung**:
@@ -46,6 +48,20 @@ Dieses Projekt extrahiert Karten aus dem Bereich **Pokémon TCG Pocket** des Ope
 4. Das Ergebnis landet in zwei Dateien:
    - `data/cards.json` mit allen Karten
    - `data/sets.json` mit den Set-Informationen
+
+## Programmatic API
+
+Seit Version 1.2 stehen zentrale Funktionen auch als Bibliothek unter
+`src/lib.ts` zur Verfügung. Damit lassen sich Karten und Sets in eigenen
+Skripten verwenden:
+
+```ts
+import { getAllSets, getAllCards, writeData } from './src/lib';
+
+const sets = await getAllSets();
+const cards = await getAllCards();
+await writeData(cards, sets);
+```
 
 ## Sicherheitshinweis
 

--- a/src/export.ts
+++ b/src/export.ts
@@ -1,33 +1,8 @@
 import 'ts-node/register';
 import fs from 'fs-extra';
 import path from 'path';
-import { glob } from 'glob';
+import { repoDir, getAllSets, getAllCards, writeData } from './lib';
 
-// Typdefinitionen
-interface SetInfo {
-  id: string;
-  [key: string]: unknown;
-}
-
-interface Card {
-  set_id?: string;
-  [key: string]: unknown;
-}
-
-// Standard-Ordner für das tcgdex-Repo
-// Kann über die Umgebungsvariable `TCGDEX_REPO` angepasst werden, um Tests
-// oder alternative Pfade zu ermöglichen.
-export const repoDir = path.resolve(process.env.TCGDEX_REPO || 'tcgdex');
-
-/**
- * Ensure that the current Node.js version meets the minimum requirement.
- *
- * @param version - Version string to validate. Defaults to `process.versions.node`.
- * @param minimumMajor - Minimum supported major Node.js version. Defaults to `20`.
- *
- * The function prints an error and exits the process with code `1` when the
- * detected major version is lower than the required version.
- */
 export function checkNodeVersion(
   version: string = process.versions.node,
   minimumMajor = 20,
@@ -39,11 +14,6 @@ export function checkNodeVersion(
   }
 }
 
-/**
- * Verify that the repository directory containing the tcgdex data exists.
- *
- * @throws Error when the directory is missing.
- */
 async function ensureRepoDir() {
   if (!(await fs.pathExists(repoDir))) {
     throw new Error(
@@ -52,126 +22,14 @@ async function ensureRepoDir() {
   }
 }
 
-const SETS_GLOB = path.join(repoDir, 'data', 'Pokémon TCG Pocket', '*.ts');
-const CARDS_GLOB = path.join(
-  repoDir,
-  'data',
-  'Pokémon TCG Pocket',
-  '*',
-  '*.ts',
-);
-
-async function importTSFile(file: string) {
-  const resolved = path.resolve(file);
-  if (!resolved.startsWith(repoDir + path.sep)) {
-    throw new Error(`Refusing to import outside of repo directory: ${file}`);
-  }
-  return await import(resolved);
-}
-
-/**
- * Read all set definition files and return them as plain objects.
- *
- * The function strips the optional `serie` field and ensures each set has a
- * name. Files are imported dynamically using `import()` which allows TypeScript
- * modules to be consumed at runtime.
- */
-async function getAllSets(): Promise<SetInfo[]> {
-  try {
-    const setFiles = await glob(SETS_GLOB);
-
-    const sets = await Promise.all(
-      setFiles.map(async (file) => {
-        try {
-          const set = (await importTSFile(file)).default;
-          // Entferne das "serie"-Feld!
-          if (set.serie) {
-            delete set.serie;
-          }
-          if (!set.name) {
-            set.name = { en: path.basename(file, '.ts') };
-          }
-          return set;
-        } catch (e) {
-          throw new Error(
-            `Failed to import set file ${file}: ${(e as Error).message}`,
-          );
-        }
-      }),
-    );
-    return sets;
-  } catch (e) {
-    throw new Error(`Failed to load sets: ${(e as Error).message}`);
-  }
-}
-
-/**
- * Load all card files and attach the corresponding set identifier.
- *
- * Each card is imported as a module. The function deduces the `set_id` from the
- * card data or the parent directory name and removes the original `set` object
- * to keep the output lean.
- */
-async function getAllCards(): Promise<Card[]> {
-  try {
-    const files = await glob(CARDS_GLOB);
-
-    const cards = await Promise.all(
-      files.map(async (file) => {
-        try {
-          const mod = await importTSFile(file);
-          const card = mod.default || mod;
-
-          let setId: string;
-          if (card.set && card.set.id) {
-            setId = card.set.id;
-          } else {
-            setId = path.basename(path.dirname(file));
-          }
-          card.set_id = setId;
-
-          // Entferne das Set-Objekt komplett aus der Karte!
-          delete card.set;
-
-          return card;
-        } catch (e) {
-          throw new Error(
-            `Failed to import card file ${file}: ${(e as Error).message}`,
-          );
-        }
-      }),
-    );
-    return cards;
-  } catch (e) {
-    throw new Error(`Failed to load cards: ${(e as Error).message}`);
-  }
-}
-
-/**
- * Orchestrates the export process from reading the repository files to writing
- * the final JSON output.
- */
 export async function main() {
   try {
     checkNodeVersion();
     await ensureRepoDir();
-    // Schritt 1: Sets einlesen
     const sets = await getAllSets();
-
-    // Schritt 2: Karten einlesen
     const cards = await getAllCards();
+    const { cardsOutPath, setsOutPath } = await writeData(cards, sets);
 
-    // Schritt 3: Schreibe Karten und Sets in getrennte Dateien
-    const dataDir = path.join(__dirname, '..', 'data');
-    await fs.ensureDir(dataDir);
-
-    const cardsOutPath = path.join(dataDir, 'cards.json');
-    const setsOutPath = path.join(dataDir, 'sets.json');
-
-    await fs.writeJson(cardsOutPath, cards, { spaces: 2 });
-    await fs.writeJson(setsOutPath, sets, { spaces: 2 });
-
-    // Debug-Ausgabe
     if (process.env.DEBUG) {
       const outRaw = await fs.readFile(cardsOutPath, 'utf-8');
       console.log('Erste 500 Zeichen aus cards.json:\n', outRaw.slice(0, 500));
@@ -180,7 +38,7 @@ export async function main() {
     }
 
     console.log(
-      `Exported ${cards.length} cards to data/cards.json and ${sets.length} sets to data/sets.json`,
+      `Exported ${cards.length} cards to ${path.relative(process.cwd(), cardsOutPath)} and ${sets.length} sets to ${path.relative(process.cwd(), setsOutPath)}`,
     );
   } catch (err) {
     console.error(err);

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,0 +1,143 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { glob } from 'glob';
+
+/**
+ * Simple async pool to process promises with limited concurrency.
+ */
+async function mapLimit<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const result: R[] = new Array(items.length);
+  let index = 0;
+  const workers = new Array(Math.min(limit, items.length))
+    .fill(0)
+    .map(async () => {
+      while (index < items.length) {
+        const current = index++;
+        result[current] = await fn(items[current]);
+      }
+    });
+  await Promise.all(workers);
+  return result;
+}
+
+// Type definitions shared with consumers
+export interface SetInfo {
+  id: string;
+  [key: string]: unknown;
+}
+
+export interface Card {
+  set_id?: string;
+  [key: string]: unknown;
+}
+
+// Default directory for the tcgdex repository. Override via TCGDEX_REPO env.
+export const repoDir = path.resolve(process.env.TCGDEX_REPO || 'tcgdex');
+
+const SETS_GLOB = path.join(repoDir, 'data', 'Pokémon TCG Pocket', '*.ts');
+const CARDS_GLOB = path.join(
+  repoDir,
+  'data',
+  'Pokémon TCG Pocket',
+  '*',
+  '*.ts',
+);
+
+async function importTSFile(file: string) {
+  const resolved = path.resolve(file);
+  if (!resolved.startsWith(repoDir + path.sep)) {
+    throw new Error(`Refusing to import outside of repo directory: ${file}`);
+  }
+  return await import(resolved);
+}
+
+/**
+ * Read all set definition files and return them as plain objects.
+ * Limits concurrency to avoid exhausting resources when many files exist.
+ */
+export async function getAllSets(): Promise<SetInfo[]> {
+  try {
+    const setFiles = await glob(SETS_GLOB);
+
+    const sets = await mapLimit(setFiles, 10, async (file) => {
+      try {
+        const set = (await importTSFile(file)).default;
+        if (set.serie) {
+          delete set.serie;
+        }
+        if (!set.name) {
+          set.name = { en: path.basename(file, '.ts') };
+        }
+        return set as SetInfo;
+      } catch (e) {
+        throw new Error(
+          `Failed to import set file ${file}: ${(e as Error).message}`,
+        );
+      }
+    });
+    return sets;
+  } catch (e) {
+    throw new Error(`Failed to load sets: ${(e as Error).message}`);
+  }
+}
+
+/**
+ * Load all card files and attach the corresponding set identifier.
+ * Concurrency is limited to improve stability.
+ */
+export async function getAllCards(): Promise<Card[]> {
+  try {
+    const files = await glob(CARDS_GLOB);
+
+    const cards = await mapLimit(files, 10, async (file) => {
+      try {
+        const mod = await importTSFile(file);
+        const card = mod.default || mod;
+
+        let setId: string;
+        if (card.set && card.set.id) {
+          setId = card.set.id;
+        } else {
+          setId = path.basename(path.dirname(file));
+        }
+        card.set_id = setId;
+
+        delete card.set;
+
+        return card as Card;
+      } catch (e) {
+        throw new Error(
+          `Failed to import card file ${file}: ${(e as Error).message}`,
+        );
+      }
+    });
+    return cards;
+  } catch (e) {
+    throw new Error(`Failed to load cards: ${(e as Error).message}`);
+  }
+}
+
+/**
+ * Write card and set data into JSON files within the given directory.
+ *
+ * @returns Paths of the written files for further processing.
+ */
+export async function writeData(
+  cards: Card[],
+  sets: SetInfo[],
+  dataDir = path.join(__dirname, '..', 'data'),
+): Promise<{ cardsOutPath: string; setsOutPath: string }> {
+  await fs.ensureDir(dataDir);
+
+  const cardsOutPath = path.join(dataDir, 'cards.json');
+  const setsOutPath = path.join(dataDir, 'sets.json');
+
+  await fs.writeJson(cardsOutPath, cards, { spaces: 2 });
+  await fs.writeJson(setsOutPath, sets, { spaces: 2 });
+
+  return { cardsOutPath, setsOutPath };
+}


### PR DESCRIPTION
## Summary
- add concurrency-limited async pool
- move card and set loaders into `src/lib.ts`
- keep CLI wrapper in `src/export.ts`
- document new programmatic API

## Testing
- `npm run lint`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a8a46355c832fa499d901642f9c03