### PR TITLE
Add logger and improve test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,5 @@ All notable changes to this project will be documented in this file.
 - Export script now throws errors instead of exiting directly.
 - Added concurrency limit for loading files and split library code into `src/lib.ts`.
 - Added security note in README.
+- Introduced logger utility and replaced direct console output.
+- Added tests for write failures and sample export.

--- a/README.md
+++ b/README.md
@@ -42,12 +42,18 @@ Dieses Projekt extrahiert Karten aus dem Bereich **Pokémon TCG Pocket** des Ope
    npm install
    npm run build
    npm test
-   npm run export
-   ```
+ npm run export
+  ```
 
 4. Das Ergebnis landet in zwei Dateien:
    - `data/cards.json` mit allen Karten
    - `data/sets.json` mit den Set-Informationen
+
+## Logausgabe
+
+Das Skript nutzt einen einfachen Logger. Meldungen erscheinen auf der Konsole
+mit einem Praefix wie `[INFO]`, `[WARN]` oder `[ERROR]`. In den Tests werden
+diese Ausgaben abgefangen.
 
 ## Programmatic API
 

--- a/src/export.ts
+++ b/src/export.ts
@@ -2,6 +2,7 @@ import 'ts-node/register';
 import fs from 'fs-extra';
 import path from 'path';
 import { repoDir, getAllSets, getAllCards, writeData } from './lib';
+import { logger } from './logger';
 
 export function checkNodeVersion(
   version: string = process.versions.node,
@@ -9,7 +10,7 @@ export function checkNodeVersion(
 ) {
   const major = parseInt(version.split('.')[0], 10);
   if (major < minimumMajor) {
-    console.error(`Node.js ${minimumMajor}+ is required. Detected ${version}.`);
+    logger.error(`Node.js ${minimumMajor}+ is required. Detected ${version}.`);
     process.exit(1);
   }
 }
@@ -32,23 +33,23 @@ export async function main() {
 
     if (process.env.DEBUG) {
       const outRaw = await fs.readFile(cardsOutPath, 'utf-8');
-      console.log('Erste 500 Zeichen aus cards.json:\n', outRaw.slice(0, 500));
+      logger.info('Erste 500 Zeichen aus cards.json:\n', outRaw.slice(0, 500));
       const setsRaw = await fs.readFile(setsOutPath, 'utf-8');
-      console.log('Erste 500 Zeichen aus sets.json:\n', setsRaw.slice(0, 500));
+      logger.info('Erste 500 Zeichen aus sets.json:\n', setsRaw.slice(0, 500));
     }
 
-    console.log(
+    logger.info(
       `Exported ${cards.length} cards to ${path.relative(process.cwd(), cardsOutPath)} and ${sets.length} sets to ${path.relative(process.cwd(), setsOutPath)}`,
     );
   } catch (err) {
-    console.error(err);
+    logger.error(err);
     throw err;
   }
 }
 
 if (require.main === module) {
   main().catch((e) => {
-    console.error(e);
+    logger.error(e);
     process.exit(1);
   });
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,21 @@
+/**
+ * Simple logger with log level prefixes.
+ *
+ * @module logger
+ */
+export const logger = {
+  /** Log informational message */
+  info: (...args: unknown[]): void => {
+    console.log('[INFO]', ...args);
+  },
+
+  /** Log warning message */
+  warn: (...args: unknown[]): void => {
+    console.warn('[WARN]', ...args);
+  },
+
+  /** Log error message */
+  error: (...args: unknown[]): void => {
+    console.error('[ERROR]', ...args);
+  },
+};

--- a/test/export-sample.test.ts
+++ b/test/export-sample.test.ts
@@ -1,0 +1,61 @@
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import { logger } from '../src/logger';
+
+/** Build a minimal tcgdex repo with one set and one card */
+async function createSampleRepo(): Promise<string> {
+  const base = await fs.mkdtemp(path.join(os.tmpdir(), 'tcgdex-'));
+  const pocketDir = path.join(base, 'data', 'Pokémon TCG Pocket', 'TEST');
+  await fs.ensureDir(pocketDir);
+  const setFile = path.join(base, 'data', 'Pokémon TCG Pocket', 'TEST.ts');
+  await fs.writeFile(
+    setFile,
+    "export default { id: 'TEST', name: { en: 'Test Set' } };",
+  );
+  const cardFile = path.join(pocketDir, 'card.ts');
+  await fs.writeFile(
+    cardFile,
+    "export default { set: { id: 'TEST' }, name: { en: 'Card' } };",
+  );
+  return base;
+}
+
+describe('export with sample data', () => {
+  let repo: string;
+  let cardsBackup: Buffer;
+  let setsBackup: Buffer;
+
+  beforeAll(() => {
+    cardsBackup = fs.readFileSync(path.join('data', 'cards.json'));
+    setsBackup = fs.readFileSync(path.join('data', 'sets.json'));
+  });
+
+  afterEach(async () => {
+    await fs.remove(repo);
+    delete process.env.TCGDEX_REPO;
+  });
+
+  afterAll(() => {
+    fs.writeFileSync(path.join('data', 'cards.json'), cardsBackup);
+    fs.writeFileSync(path.join('data', 'sets.json'), setsBackup);
+  });
+
+  it('exports tiny dataset', async () => {
+    repo = await createSampleRepo();
+    process.env.TCGDEX_REPO = repo;
+    const logSpy = jest.spyOn(logger, 'info').mockImplementation(() => {});
+    const { main } = await import('../src/export');
+    await main();
+    await expect(
+      fs.readJson(path.join('data', 'cards.json')),
+    ).resolves.toHaveLength(1);
+    await expect(
+      fs.readJson(path.join('data', 'sets.json')),
+    ).resolves.toHaveLength(1);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Exported 1 cards'),
+    );
+    logSpy.mockRestore();
+  });
+});

--- a/test/export.test.ts
+++ b/test/export.test.ts
@@ -1,6 +1,7 @@
 import 'ts-node/register';
 import fs from 'fs-extra';
 import path from 'path';
+import { logger } from '../src/logger';
 
 async function repoExists(repoDir: string): Promise<boolean> {
   return fs.pathExists(repoDir);
@@ -12,7 +13,7 @@ describe('export script', () => {
   it('runs export when repo present', async () => {
     const defaultRepo = path.resolve('tcgdex');
     if (!(await repoExists(defaultRepo))) {
-      console.log('Skipping export test: repo directory not found');
+      logger.info('Skipping export test: repo directory not found');
       return;
     }
     jest.resetModules();

--- a/test/node-version.test.ts
+++ b/test/node-version.test.ts
@@ -1,11 +1,12 @@
 import { checkNodeVersion } from '../src/export';
+import { logger } from '../src/logger';
 
 describe('checkNodeVersion', () => {
   it('exits when node major version is below 20', () => {
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('exit');
     });
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
 
     expect(() => checkNodeVersion('18.0.0')).toThrow('exit');
     expect(errorSpy).toHaveBeenCalledWith(

--- a/test/write-data.test.ts
+++ b/test/write-data.test.ts
@@ -1,0 +1,18 @@
+import fs from 'fs-extra';
+import { writeData } from '../src/lib';
+
+jest.mock('fs-extra', () => {
+  const actual = jest.requireActual('fs-extra');
+  return {
+    ...actual,
+    writeJson: jest.fn(),
+  };
+});
+
+describe('writeData', () => {
+  it('throws when fs.writeJson fails', async () => {
+    const error = new Error('disk full');
+    (fs.writeJson as jest.Mock).mockRejectedValueOnce(error);
+    await expect(writeData([], [])).rejects.toThrow('disk full');
+  });
+});


### PR DESCRIPTION
## Summary
- add a tiny logger utility
- use the logger inside the export script
- document log output
- test writeData failures and a small end-to-end export
- update existing tests for logger usage

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a8c7f57b0832f91d29289c2442e3a