### PR TITLE
Refactor export CLI error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Updated documentation and tests.
 - Improved path validation and error handling in export script.
 - Export script now throws errors instead of exiting directly.
+- Node version check throws an error; CLI logs once and exits with code 1.
 - Added concurrency limit for loading files and split library code into `src/lib.ts`.
 - Added security note in README.
 - Introduced logger utility and replaced direct console output.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Dieses Projekt extrahiert Karten aus dem Bereich **Pokémon TCG Pocket** des Ope
 ## Voraussetzungen
 
 - Benötigt wird **Node.js 20 oder neuer** (siehe GitHub Action)
-- Das Export-Skript prüft die Node.js-Version und bricht bei zu niedrigen
-  Versionen mit einer Fehlermeldung ab.
+- Das Export-Skript prüft die Node.js-Version. Ist sie zu niedrig,
+  wird ein Fehler geworfen und die CLI beendet sich mit Exit-Code 1.
 - Bitte aktualisiere die Dokumentation, wenn sich Funktionen oder Verhalten
   ändern.
 - Vor dem Export muss ein Klon von `tcgdex/cards-database` im Unterordner
@@ -35,7 +35,7 @@ Dieses Projekt extrahiert Karten aus dem Bereich **Pokémon TCG Pocket** des Ope
    git clone https://github.com/tcgdex/cards-database tcgdex
    ```
    Das Skript erwartet einen Ordner `tcgdex` im Projektverzeichnis. Fehlt er,
-   schlägt `npm run export` mit einer Fehlermeldung fehl.
+   gibt die CLI eine Fehlermeldung aus und beendet sich mit Code 1.
 4. Abhängigkeiten installieren, Build erzeugen, Tests ausführen und Export starten:
 
    ```bash

--- a/src/export.ts
+++ b/src/export.ts
@@ -10,8 +10,9 @@ export function checkNodeVersion(
 ) {
   const major = parseInt(version.split('.')[0], 10);
   if (major < minimumMajor) {
-    logger.error(`Node.js ${minimumMajor}+ is required. Detected ${version}.`);
-    process.exit(1);
+    const message = `Node.js ${minimumMajor}+ is required. Detected ${version}.`;
+    logger.error(message);
+    throw new Error(message);
   }
 }
 
@@ -24,27 +25,22 @@ async function ensureRepoDir() {
 }
 
 export async function main() {
-  try {
-    checkNodeVersion();
-    await ensureRepoDir();
-    const sets = await getAllSets();
-    const cards = await getAllCards();
-    const { cardsOutPath, setsOutPath } = await writeData(cards, sets);
+  checkNodeVersion();
+  await ensureRepoDir();
+  const sets = await getAllSets();
+  const cards = await getAllCards();
+  const { cardsOutPath, setsOutPath } = await writeData(cards, sets);
 
-    if (process.env.DEBUG) {
-      const outRaw = await fs.readFile(cardsOutPath, 'utf-8');
-      logger.info('Erste 500 Zeichen aus cards.json:\n', outRaw.slice(0, 500));
-      const setsRaw = await fs.readFile(setsOutPath, 'utf-8');
-      logger.info('Erste 500 Zeichen aus sets.json:\n', setsRaw.slice(0, 500));
-    }
-
-    logger.info(
-      `Exported ${cards.length} cards to ${path.relative(process.cwd(), cardsOutPath)} and ${sets.length} sets to ${path.relative(process.cwd(), setsOutPath)}`,
-    );
-  } catch (err) {
-    logger.error(err);
-    throw err;
+  if (process.env.DEBUG) {
+    const outRaw = await fs.readFile(cardsOutPath, 'utf-8');
+    logger.info('Erste 500 Zeichen aus cards.json:\n', outRaw.slice(0, 500));
+    const setsRaw = await fs.readFile(setsOutPath, 'utf-8');
+    logger.info('Erste 500 Zeichen aus sets.json:\n', setsRaw.slice(0, 500));
   }
+
+  logger.info(
+    `Exported ${cards.length} cards to ${path.relative(process.cwd(), cardsOutPath)} and ${sets.length} sets to ${path.relative(process.cwd(), setsOutPath)}`,
+  );
 }
 
 if (require.main === module) {

--- a/test/export.test.ts
+++ b/test/export.test.ts
@@ -32,7 +32,14 @@ describe('export script', () => {
     jest.resetModules();
     process.env.TCGDEX_REPO = '__invalid__';
     const { main } = await import('../src/export');
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+
     await expect(main()).rejects.toThrow(/Repo directory/);
+    expect(exitSpy).not.toHaveBeenCalled();
+
+    exitSpy.mockRestore();
     delete process.env.TCGDEX_REPO;
   });
 });

--- a/test/node-version.test.ts
+++ b/test/node-version.test.ts
@@ -2,28 +2,20 @@ import { checkNodeVersion } from '../src/export';
 import { logger } from '../src/logger';
 
 describe('checkNodeVersion', () => {
-  it('exits when node major version is below 20', () => {
-    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('exit');
-    });
+  it('throws when node major version is below 20', () => {
     const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
 
-    expect(() => checkNodeVersion('18.0.0')).toThrow('exit');
+    expect(() => checkNodeVersion('18.0.0')).toThrow(
+      /Node.js 20\+ is required/,
+    );
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('Node.js 20+'),
     );
 
-    exitSpy.mockRestore();
     errorSpy.mockRestore();
   });
 
-  it('does not exit when node version is higher', () => {
-    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('exit');
-    });
-
+  it('does not throw when node version is higher', () => {
     expect(() => checkNodeVersion('21.0.0')).not.toThrow();
-
-    exitSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- throw an error instead of exiting if Node.js is too old
- simplify `main` error handling
- ensure CLI only logs once and exits
- update tests for thrown errors
- document exit behaviour change

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a90280c80832f897a6d9422e1c595