### PR TITLE
Improve typing and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@ All notable changes to this project will be documented in this file.
 - Added tests for write failures and sample export.
 - Repo directory path is now validated on startup and must lie within the project.
 - New `CONCURRENCY` env variable allows adjusting parallel file loading.
+- Extended TypeScript interfaces and improved documentation of JSON format.

--- a/docs/json-format.md
+++ b/docs/json-format.md
@@ -10,15 +10,14 @@ Beide Dateien liegen als Arrays vor, sodass sie unabhängig voneinander eingeles
 
 ## Karten
 
-`cards` enthält die eigentlichen Karteneinträge. Sie besitzen im Wesentlichen die gleichen Felder wie die Originaldaten aus [`tcgdex/cards-database`](https://github.com/tcgdex/cards-database) und zusätzlich einige Hilfsfelder. Zur schnellen Zuordnung sind `set_id` und `set_name` direkt auf Kartenebene abgelegt. Ein vollständiges `set`-Objekt wird nicht mehr gespeichert.
+`cards` enthält die eigentlichen Karteneinträge. Sie besitzen im Wesentlichen die gleichen Felder wie die Originaldaten aus [`tcgdex/cards-database`](https://github.com/tcgdex/cards-database) und zusätzlich einige Hilfsfelder. Zur schnellen Zuordnung ist `set_id` direkt auf Kartenebene abgelegt. Ein vollständiges `set`-Objekt wird nicht mehr gespeichert.
 
 Wichtige Felder eines Karteneintrags:
 
 - `set_id`: Die Set-ID als String (entspricht der ID im zugehörigen Set)
-- `set_name`: Der englische Name des Sets
 - `name`: Kartennamen in verschiedenen Sprachen
 - `illustrator`, `rarity`, `category`, `hp`, `types`, `stage`, `suffix` usw.
-- `boosters`: Liste der Booster-IDs, in denen die Karte erscheint
+- `boosters`: Liste der Booster-IDs, in denen die Karte erscheint (optional)
 
 Die genaue Struktur kann je nach Karte variieren, da auch Attacken, Fähigkeiten und andere optionale Felder enthalten sind.
 
@@ -48,7 +47,6 @@ Ein minimales Pack-Objekt sieht so aus:
   "rarity": "Crown",
   "types": ["Colorless"],
   "set_id": "A2a",
-  "set_name": "Triumphant Light",
   "boosters": ["dialga", "palkia"]
 }
 ```
@@ -56,6 +54,6 @@ Ein minimales Pack-Objekt sieht so aus:
 ## Hinweise für Verbraucher
 
 - Die Datei kann sehr groß werden. Wer nur einige Felder benötigt, kann beim Einlesen nicht relevante Eigenschaften ignorieren.
-- Die Felder `set_id` und `set_name` sind rein zur Bequemlichkeit vorhanden und entsprechen exakt den Angaben im zugehörigen Set.
+- Das Feld `set_id` ist rein zur Bequemlichkeit vorhanden und entspricht exakt den Angaben im zugehörigen Set.
 - Über das Feld `boosters` lässt sich ermitteln, in welchem Pack eine Karte erscheint. Die tatsächlichen Namen der Boosterpacks stehen im `sets`-Abschnitt.
 - Bei zukünftigen Änderungen des Skripts kann sich die Struktur anpassen. Anwendungen sollten daher möglichst fehlertolerant parsen.

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -4,6 +4,11 @@ import { glob } from 'glob';
 
 /**
  * Simple async pool to process promises with limited concurrency.
+ *
+ * @param items Array of items to process
+ * @param limit Maximum number of concurrent executions
+ * @param fn    Async function applied to each item
+ * @returns Results in the same order as `items`
  */
 async function mapLimit<T, R>(
   items: T[],
@@ -26,12 +31,24 @@ async function mapLimit<T, R>(
 
 // Type definitions shared with consumers
 export interface SetInfo {
+  /** Unique identifier of the set */
   id: string;
+  /** Set name in multiple languages */
+  name?: Record<string, string>;
+  /** Number of cards in the set */
+  cardCount?: { official: number };
+  /** Mapping of booster IDs to booster info */
+  boosters?: Record<string, { name: Record<string, string> }>;
+  /** Release date as ISO string */
+  releaseDate?: string;
   [key: string]: unknown;
 }
 
 export interface Card {
-  set_id?: string;
+  /** Identifier of the set this card belongs to */
+  set_id: string;
+  /** List of booster IDs this card appears in */
+  boosters?: string[];
   [key: string]: unknown;
 }
 
@@ -78,7 +95,8 @@ async function importTSFile(file: string) {
 /**
  * Read all set definition files and return them as plain objects.
  *
- * @param concurrency Maximum number of files loaded in parallel.
+ * @param concurrency Maximum number of files loaded in parallel
+ * @returns Array of `SetInfo` objects
  */
 export async function getAllSets(
   concurrency = Number(process.env.CONCURRENCY) || 10,
@@ -111,7 +129,8 @@ export async function getAllSets(
 /**
  * Load all card files and attach the corresponding set identifier.
  *
- * @param concurrency Maximum number of files loaded in parallel.
+ * @param concurrency Maximum number of files loaded in parallel
+ * @returns Array of `Card` objects
  */
 export async function getAllCards(
   concurrency = Number(process.env.CONCURRENCY) || 10,
@@ -150,7 +169,10 @@ export async function getAllCards(
 /**
  * Write card and set data into JSON files within the given directory.
  *
- * @returns Paths of the written files for further processing.
+ * @param cards Array of card objects to write
+ * @param sets  Array of set objects to write
+ * @param dataDir Output directory for the JSON files
+ * @returns Paths of the written files for further processing
  */
 export async function writeData(
   cards: Card[],


### PR DESCRIPTION
## Summary
- extend `Card` and `SetInfo` interfaces with optional fields
- document library functions with JSDoc
- clarify JSON format docs and remove `set_name`
- document changes in `CHANGELOG`

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a97a05ebc832f988fdcc8e016798f