### PR TITLE
Improve concurrency validation and logging

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Lint
+        run: npm run lint
+
       - name: Test
         run: npm test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Added validation for the `CONCURRENCY` environment variable; values must be positive integers.
+- `mapLimit` now throws an error when the concurrency limit is zero or negative.
+- `writeData` writes files atomically via temporary files.
+- Logger outputs now include timestamps.
+- GitHub workflow runs linting and collects test coverage.
+- Documentation updated to describe new behavior and environment variable rules.
+
 - Allow running on Node.js 20 or newer.
 - Updated documentation and tests.
 - Improved path validation and error handling in export script.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ npm install
 npm run build
 npm run lint
 npm test
+# Testabdeckung wird automatisch erzeugt und im Ordner `coverage/` abgelegt
 ```
 
 ## Hinweise

--- a/README.md
+++ b/README.md
@@ -54,13 +54,14 @@ npm run export
 - `TCGDEX_REPO` legt den Pfad zum Klon von `tcgdex/cards-database` fest. Der Pfad
   muss innerhalb des Projektverzeichnisses liegen und vorhanden sein, sonst bricht
   das Skript mit einer Fehlermeldung ab.
-- `CONCURRENCY` bestimmt, wie viele Dateien parallel eingelesen werden (Standard: 10).
+- `CONCURRENCY` legt die Anzahl paralleler Ladevorgänge fest (Standard: 10). Der Wert muss eine positive Ganzzahl sein;
+  ungültige Eingaben werden ignoriert und auf 10 gesetzt.
 
 ## Logausgabe
 
-Das Skript nutzt einen einfachen Logger. Meldungen erscheinen auf der Konsole
-mit einem Praefix wie `[INFO]`, `[WARN]` oder `[ERROR]`. In den Tests werden
-diese Ausgaben abgefangen.
+Der Logger schreibt Meldungen mit Zeitstempel und Loglevel auf die Konsole,
+etwa `[INFO 2025-06-24T12:00:00.000Z]`. In den Tests werden diese Ausgaben
+abgefangen.
 
 ## Programmatic API
 

--- a/docs/json-format.md
+++ b/docs/json-format.md
@@ -6,7 +6,9 @@ Das Skript `src/export.ts` erzeugt zwei Dateien im Verzeichnis `data/`:
 - **`cards.json`** – enthält eine Liste aller Karten.
 - **`sets.json`** – enthält Informationen zu allen Sets bzw. Boostern.
 
-Beide Dateien liegen als Arrays vor, sodass sie unabhängig voneinander eingelesen werden können. Seit Version 1.1 werden die Quelldateien parallel eingelesen, was die Ausführung beschleunigt.
+Beide Dateien liegen als Arrays vor, sodass sie unabhängig voneinander eingelesen werden können. Seit Version 1.1 werden die Quelldateien parallel eingelesen, was die Ausführung beschleunigt. Die Anzahl der gleichzeitigen Ladevorgänge lässt sich über die Umgebungsvariable `CONCURRENCY` steuern (positive Ganzzahl, Standard: 10).
+
+Der Schreibvorgang erfolgt atomar, indem die Dateien zunächst als temporäre `.tmp`-Dateien angelegt und erst danach verschoben werden.
 
 ## Karten
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
 };

--- a/src/export.ts
+++ b/src/export.ts
@@ -1,7 +1,7 @@
 import 'ts-node/register';
 import fs from 'fs-extra';
 import path from 'path';
-import { getAllSets, getAllCards, writeData } from './lib';
+import { getAllSets, getAllCards, writeData, parseConcurrency } from './lib';
 import { logger } from './logger';
 
 export function checkNodeVersion(
@@ -18,7 +18,7 @@ export function checkNodeVersion(
 
 export async function main() {
   checkNodeVersion();
-  const concurrency = Number(process.env.CONCURRENCY) || 10;
+  const concurrency = parseConcurrency(process.env.CONCURRENCY);
   const sets = await getAllSets(concurrency);
   const cards = await getAllCards(concurrency);
   const { cardsOutPath, setsOutPath } = await writeData(cards, sets);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,19 +3,31 @@
  *
  * @module logger
  */
+function log(level: 'info' | 'warn' | 'error', ...args: unknown[]): void {
+  const timestamp = new Date().toISOString();
+  const prefix = `[${level.toUpperCase()} ${timestamp}]`;
+  if (level === 'error') {
+    console.error(prefix, ...args);
+  } else if (level === 'warn') {
+    console.warn(prefix, ...args);
+  } else {
+    console.log(prefix, ...args);
+  }
+}
+
 export const logger = {
   /** Log informational message */
   info: (...args: unknown[]): void => {
-    console.log('[INFO]', ...args);
+    log('info', ...args);
   },
 
   /** Log warning message */
   warn: (...args: unknown[]): void => {
-    console.warn('[WARN]', ...args);
+    log('warn', ...args);
   },
 
   /** Log error message */
   error: (...args: unknown[]): void => {
-    console.error('[ERROR]', ...args);
+    log('error', ...args);
   },
 };

--- a/test/concurrency.test.ts
+++ b/test/concurrency.test.ts
@@ -1,0 +1,49 @@
+beforeAll(() => {
+  process.env.TCGDEX_REPO = process.cwd();
+});
+
+afterAll(() => {
+  delete process.env.TCGDEX_REPO;
+});
+
+import fs from 'fs-extra';
+import path from 'path';
+
+async function createSampleRepo(): Promise<string> {
+  const base = await fs.mkdtemp(path.join(process.cwd(), 'tmp-repo-'));
+  const pocketDir = path.join(base, 'data', 'Pokémon TCG Pocket', 'T');
+  await fs.ensureDir(pocketDir);
+  await fs.writeFile(
+    path.join(base, 'data', 'Pokémon TCG Pocket', 'T.ts'),
+    "export default { id: 'T' };",
+  );
+  await fs.writeFile(
+    path.join(pocketDir, 'c.ts'),
+    "export default { set: { id: 'T' } };",
+  );
+  return base;
+}
+
+describe('parseConcurrency', () => {
+  it('returns default for invalid values', async () => {
+    const { parseConcurrency } = await import('../src/lib');
+    expect(parseConcurrency('0')).toBe(10);
+    expect(parseConcurrency('-2')).toBe(10);
+    expect(parseConcurrency('abc')).toBe(10);
+  });
+
+  it('parses valid numbers', async () => {
+    const { parseConcurrency } = await import('../src/lib');
+    expect(parseConcurrency('5')).toBe(5);
+  });
+});
+
+describe('mapLimit validation via getAllSets', () => {
+  it('throws for concurrency 0', async () => {
+    const repo = await createSampleRepo();
+    process.env.TCGDEX_REPO = repo;
+    const { getAllSets } = await import('../src/lib');
+    await expect(getAllSets(0)).rejects.toThrow(/Invalid concurrency limit/);
+    await fs.remove(repo);
+  });
+});

--- a/test/write-data.test.ts
+++ b/test/write-data.test.ts
@@ -19,5 +19,7 @@ describe('writeData', () => {
     const error = new Error('disk full');
     (fs.writeJson as jest.Mock).mockRejectedValueOnce(error);
     await expect(writeData([], [])).rejects.toThrow('disk full');
+    const tmpExists = await fs.pathExists('data/cards.json.tmp');
+    expect(tmpExists).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- validate CONCURRENCY env value with `parseConcurrency`
- enforce concurrency limit in `mapLimit`
- write files atomically in `writeData`
- add timestamped logger output
- document new behaviour and update workflow
- extend tests and collect coverage

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a99371d28832fa1d66abb8774e19f