### PR TITLE
Update tsconfig and add CLI args test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,6 @@ All notable changes to this project will be documented in this file.
 - Temporary files are cleaned up on write failures.
 - Repository path validation rejects symbolic links outside the project.
 - Development dependencies updated (e.g., @types/node).
+- Updated @types/node to version 24.0.4.
+- TypeScript config now includes `"lib": ["es2020"]` for newer APIs.
+- Added tests for CLI argument parsing.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Dieses Projekt extrahiert Karten aus dem Bereich **Pokémon TCG Pocket** des Ope
 - Benötigt wird **Node.js 20 oder neuer** (siehe GitHub Action)
 - Das Export-Skript prüft die Node.js-Version. Ist sie zu niedrig,
   wird ein Fehler geworfen und die CLI beendet sich mit Exit-Code 1.
+- Die `tsconfig.json` nutzt jetzt `"lib": ["es2020"]`, sodass Funktionen wie
+  `Promise.allSettled` korrekt typisiert sind.
+- Die mitgelieferten TypeScript-Definitionen für Node wurden auf Version
+  24.0.4 aktualisiert.
 - Bitte aktualisiere die Dokumentation, wenn sich Funktionen oder Verhalten
   ändern.
 - Vor dem Export muss ein Klon von `tcgdex/cards-database` im Unterordner

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@eslint/js": "^9.29.0",
         "@types/fs-extra": "^11.0.4",
         "@types/jest": "^30.0.0",
-        "@types/node": "^24.0.3",
+        "@types/node": "^24.0.4",
         "@typescript-eslint/eslint-plugin": "^8.35.0",
         "@typescript-eslint/parser": "^8.35.0",
         "eslint": "^9.29.0",
@@ -1775,9 +1775,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
-      "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
+      "version": "24.0.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.4.tgz",
+      "integrity": "sha512-ulyqAkrhnuNq9pB76DRBTkcS6YsmDALy6Ua63V8OhrOBgbcYt6IOdzpw5P1+dyRIyMerzLkeYWBeOXPpA9GMAA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@eslint/js": "^9.29.0",
     "@types/fs-extra": "^11.0.4",
     "@types/jest": "^30.0.0",
-    "@types/node": "^24.0.3",
+    "@types/node": "^24.0.4",
     "@typescript-eslint/eslint-plugin": "^8.35.0",
     "@typescript-eslint/parser": "^8.35.0",
     "eslint": "^9.29.0",

--- a/src/export.ts
+++ b/src/export.ts
@@ -9,7 +9,14 @@ interface CliOptions {
   out?: string;
 }
 
-function parseArgs(argv: string[]): CliOptions {
+/**
+ * Parse command line arguments for the export CLI.
+ *
+ * Supported flags:
+ *   - `--concurrency` or `-c` followed by a number to limit parallel file reads.
+ *   - `--out` or `-o` followed by a directory path for JSON output.
+ */
+export function parseArgs(argv: string[]): CliOptions {
   const opts: CliOptions = {};
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];

--- a/test/parse-args.test.ts
+++ b/test/parse-args.test.ts
@@ -1,0 +1,27 @@
+process.env.TCGDEX_REPO = process.cwd();
+import * as exp from '../src/export';
+
+afterAll(() => {
+  delete process.env.TCGDEX_REPO;
+});
+
+interface CliOptions {
+  concurrency?: number;
+  out?: string;
+}
+
+describe('parseArgs', () => {
+  const parse = (
+    exp as unknown as { parseArgs: (argv: string[]) => CliOptions }
+  ).parseArgs;
+
+  it('reads --concurrency and --out', () => {
+    const opts = parse(['--concurrency', '5', '--out', 'foo']);
+    expect(opts).toEqual({ concurrency: 5, out: 'foo' });
+  });
+
+  it('reads short flags -c and -o', () => {
+    const opts = parse(['-c', '7', '-o', 'bar']);
+    expect(opts).toEqual({ concurrency: 7, out: 'bar' });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
       "esModuleInterop": true,
       "outDir": "dist",
       "strict": true,
-      "skipLibCheck": true
+      "skipLibCheck": true,
+      "lib": ["es2020"]
     },
     "include": ["src/**/*"]
   }


### PR DESCRIPTION
## Summary
- support ES2020 library features
- bump @types/node
- export `parseArgs` and document its flags
- add tests for parseArgs
- update changelog and docs

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685adda53378832fbae8c4f3938454bc