### PR TITLE
Fix Snyk guards in CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,6 @@ LOG_MAX_SIZE=
 
 # Print first 500 characters of output after export when set
 DEBUG=
+
+# Optional: token for Snyk security scans (used in CI)
+SNYK_TOKEN=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           RAILWAY_SERVICE: ${{ secrets.RAILWAY_SERVICE || '' }}
           RAILWAY_ENV: ${{ secrets.RAILWAY_ENV || '' }}
       - name: Snyk Test
-        if: ${{ secrets.SNYK_TOKEN != '' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ env.SNYK_TOKEN != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
         run: snyk test
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -129,9 +129,8 @@ Prettier und ESLint laufen dabei auch die Python-Linter **Black**,
 Die GitHub-Actions führen Linting, Pre-commit-Prüfungen (Prettier,
 ESLint, Black, Flake8, Ruff und `pip-audit`), Tests und einen
 `npx snyk test`-Scan aus. Da Secrets in Pull Requests von Forks nicht
-verfügbar sind, läuft dieser Schritt nur, wenn das `SNYK_TOKEN`-Secret
-gesetzt ist und der PR aus demselben Repository stammt. So verhindern
-wir Authentifizierungsfehler.
+verfügbar sind, prüft ein Guard, ob `SNYK_TOKEN` gesetzt ist und der PR
+nicht aus einem Fork stammt. So verhindern wir Authentifizierungsfehler.
 Abhängigkeiten und Pre-commit-Umgebungen werden über `actions/cache`
 zwischengespeichert. Nach dem Lauf wird `railway logs --follow`
 ausgeführt und als `logs/latest_railway.log` hochgeladen. Zusätzlich wird die


### PR DESCRIPTION
## Summary
- guard Snyk step with environment variable
- document SNYK_TOKEN in README and `.env.example`

## Testing
- `pre-commit run --files .github/workflows/ci.yml README.md .env.example`
- `npm test -- --coverage` *(fails: Cannot find type definition file for 'jest')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_685d2c2376bc832f94f6ab119e87f3f0